### PR TITLE
Allow users to customize the default listener

### DIFF
--- a/src/eunit.erl
+++ b/src/eunit.erl
@@ -144,7 +144,7 @@ test(Tests, Options) ->
 %% @private
 %% @doc See {@link test/2}.
 test(Server, Tests, Options) ->
-    Listeners = [eunit_tty:start(Options) | listeners(Options)],
+    Listeners = default_listener(Options) ++ listeners(Options),
     Serial = eunit_serial:start(Listeners),
     case eunit_server:start_test(Server, Serial, Tests, Options) of
 	{ok, Reference} -> test_run(Reference, Listeners);
@@ -197,6 +197,10 @@ submit(T, Options) ->
 submit(Server, T, Options) ->
     Dummy = spawn(fun devnull/0),
     eunit_server:start_test(Server, Dummy, T, Options).
+
+default_listener(Options) ->
+    start_listeners([proplists:get_value(default_report, Options,
+                                        {eunit_tty, Options})]).
 
 listeners(Options) ->
     Ps = start_listeners(proplists:get_all_values(report, Options)),


### PR DESCRIPTION
Hi,

I was experimenting with a report listener that can print colorized output to the terminal in a style modeled after rspec. In order to do that and not have eunit_tty run, I had to create my own copy of eunit to setup listeners and initiate the run. So here's a patch that allows the default report listener to be customized.

Users can specify a custom default listener by adding a tuple like the
following to the Options list passed to test/2:

```
{default_report, {Mod, ModOpts}}
```

If present, Mod:start(ModOpts) will be called and this listener will
be installed. If a default_report key is not provided in the options
list, eunit_tty is enabled; the default behavior does not
change.
