### PR TITLE
Escape UTF-8 chars > 127 in surefire XML

### DIFF
--- a/src/eunit_surefire.erl
+++ b/src/eunit_surefire.erl
@@ -237,7 +237,7 @@ write_reports(TestSuites, XmlDir) ->
 
 write_report(#testsuite{name = Name} = TestSuite, XmlDir) ->
     Filename = filename:join(XmlDir, lists:flatten(["TEST-", escape_suitename(Name)], ".xml")),
-    case file:open(Filename, [write, raw]) of
+    case file:open(Filename, [write,{encoding,utf8}]) of
         {ok, FileDescriptor} ->
             try
                 write_report_to(TestSuite, FileDescriptor)


### PR DESCRIPTION
The hudson XML parser will crash if there is a char bigger than 127 in the result XML. This patch escapes any of those characters so that the hudson parser remains happy.
