### PR TITLE
Change default test timeout from 5 seconds to infinity

### DIFF
--- a/src/eunit_internal.hrl
+++ b/src/eunit_internal.hrl
@@ -26,7 +26,7 @@
 -define(DEFAULT_EXPORT_SUFFIX, "_exported_").
 -define(DEFAULT_TESTMODULE_SUFFIX, "_tests").
 -define(DEFAULT_GROUP_TIMEOUT, infinity).
--define(DEFAULT_TEST_TIMEOUT, 5000).
+-define(DEFAULT_TEST_TIMEOUT, infinity).
 -define(DEFAULT_SETUP_PROCESS, spawn).
 -define(DEFAULT_MODULE_WRAPPER_NAME, eunit_wrapper_).
 


### PR DESCRIPTION
Typically test frameworks are not opinionated on how long tests take to run. They sometimes provide ways to enforce time limits, but they do not enforce it by default. EUnit should behave similarly for uniformity's sake.

Examples of such frameworks:
- [unittest](https://docs.python.org/3.6/library/unittest.html) in Python
- [junit](https://github.com/junit-team/junit4/wiki/timeout-for-tests) in Java
- [hunit](https://github.com/hspec/HUnit) in Haskell
- Rust's unit tests [print but don't abort](https://github.com/rust-lang/rust/issues/37461) if they take a long time
- gtest in C++ [does not have timeouts](https://github.com/google/googletest/issues/348) at all